### PR TITLE
Athletes filters

### DIFF
--- a/athletes/paginations.py
+++ b/athletes/paginations.py
@@ -1,0 +1,6 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class AthletePagination(PageNumberPagination):
+    page_size = 6
+    page_size_query_param = 'page_size'

--- a/athletes/serializers.py
+++ b/athletes/serializers.py
@@ -28,9 +28,4 @@ class AthleteSerializer(serializers.ModelSerializer):
 
 
 class DetailAthleteSerializer(AthleteSerializer):
-    participations = serializers.SerializerMethodField()
-
-    def get_participations(self, athlete):
-        participations = Participation.objects.filter(athlete=athlete).all()
-        serializer = ParticipationSerializer(participations, many=True, context={"request": self.context.get('request')})
-        return serializer.data
+    participations = ParticipationSerializer(read_only=True, many=True, source='participation_set')

--- a/athletes/views.py
+++ b/athletes/views.py
@@ -1,6 +1,7 @@
 from rest_framework import viewsets
 from .models import Athlete
 from .serializers import AthleteSerializer, DetailAthleteSerializer
+from .paginations import AthletePagination
 
 
 class AthleteViewSet(viewsets.ModelViewSet):
@@ -9,6 +10,7 @@ class AthleteViewSet(viewsets.ModelViewSet):
     detail_serializer_class = DetailAthleteSerializer
     http_method_names = ['get']
     filter_fields = ['participation__modality__sport', 'participation__modality']
+    pagination_class = AthletePagination
 
     def get_serializer_class(self):
         if self.action == 'retrieve':

--- a/athletes/views.py
+++ b/athletes/views.py
@@ -8,6 +8,7 @@ class AthleteViewSet(viewsets.ModelViewSet):
     serializer_class = AthleteSerializer
     detail_serializer_class = DetailAthleteSerializer
     http_method_names = ['get']
+    filter_fields = ['participation__modality__sport', 'participation__modality']
 
     def get_serializer_class(self):
         if self.action == 'retrieve':

--- a/core/settings.py
+++ b/core/settings.py
@@ -184,8 +184,6 @@ CORS_ORIGIN_ALLOW_ALL = True
 SITE_ID = 1
 
 REST_FRAMEWORK = {
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 6,
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
     ],

--- a/core/settings.py
+++ b/core/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     'participations',
     'sports',
     'storages',
+    'django_filters',
 ]
 
 MIDDLEWARE = [
@@ -198,3 +199,5 @@ REST_AUTH_REGISTER_SERIALIZERS = {
 }
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+REST_FRAMEWORK['DEFAULT_FILTER_BACKENDS'] = ('django_filters.rest_framework.DjangoFilterBackend',)

--- a/participations/serializers.py
+++ b/participations/serializers.py
@@ -13,13 +13,13 @@ class CommentarySerializer(serializers.ModelSerializer):
 
 class ParticipationSerializer(serializers.ModelSerializer):
     modality = ModalitySerializer(read_only=True)
-    comentaries = serializers.SerializerMethodField()
+    commentaries = serializers.SerializerMethodField()
 
     class Meta:
         model = Participation
         exclude = ['athlete']
 
-    def get_comentaries(self, participation):
+    def get_commentaries(self, participation):
         sports = Commentary.objects.filter(participation=participation).distinct().all()
         serializer = CommentarySerializer(sports, many=True, context={"request": self.context.get('request')})
         return serializer.data

--- a/participations/serializers.py
+++ b/participations/serializers.py
@@ -13,13 +13,8 @@ class CommentarySerializer(serializers.ModelSerializer):
 
 class ParticipationSerializer(serializers.ModelSerializer):
     modality = ModalitySerializer(read_only=True)
-    commentaries = serializers.SerializerMethodField()
+    commentaries = CommentarySerializer(read_only=True, many=True, source="commentary_set")
 
     class Meta:
         model = Participation
         exclude = ['athlete']
-
-    def get_commentaries(self, participation):
-        sports = Commentary.objects.filter(participation=participation).distinct().all()
-        serializer = CommentarySerializer(sports, many=True, context={"request": self.context.get('request')})
-        return serializer.data

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ defusedxml==0.6.0
 Django==3.0.3
 django-allauth==0.41.0
 django-cors-headers==3.2.1
+django-filter==2.2.0
 django-rest-auth==0.9.5
 django-storages==1.9.1
 djangorestframework==3.11.0

--- a/sports/urls.py
+++ b/sports/urls.py
@@ -1,6 +1,7 @@
 from rest_framework import routers
 
-from sports.views import SportViewSet
+from .views import SportViewSet, ModalityViewSet
 
 router = routers.DefaultRouter()
 router.register('sports', SportViewSet)
+router.register('modalities', ModalityViewSet)

--- a/sports/views.py
+++ b/sports/views.py
@@ -1,10 +1,17 @@
 from rest_framework import viewsets
 
-from .models import Sport
-from .serializers import SportSerializer
+from .models import Sport, Modality
+from .serializers import SportSerializer, ModalitySerializer
 
 
 class SportViewSet(viewsets.ModelViewSet):
     queryset = Sport.objects.all().order_by('id')
     serializer_class = SportSerializer
     http_method_names = ['get']
+
+
+class ModalityViewSet(viewsets.ModelViewSet):
+    queryset = Modality.objects.all().order_by('id')
+    serializer_class = ModalitySerializer
+    http_method_names = ['get']
+    filter_fields = ['sport']


### PR DESCRIPTION
**Uso filtros para atleta (deporte/modalidad)**
```sh
GET /api/v1/athletes/?participation__modality__sport=1&participation__modality=1
HTTP 200 OK
Allow: GET
Content-Type: application/json
Vary: Accept

{
    "count": 4,
    "next": null,
    "previous": null,
    "results": [
        {
            "id": 1,
            "trainer": {
                "id": 1,
                "first_name": "a",
                "last_name": "a"
            },
            "birth_place": "Manizales",
            "sports": [ 
            ...
```

**Lista de modalidades por deporte**
```sh
GET /api/v1/modalities/?sport=1
HTTP 200 OK
Allow: GET
Content-Type: application/json
Vary: Accept

[
    {
        "id": 1,
        "sport": {
            "id": 1,
            "name": "Natacion",
            "icon": "http://localhost:8000/media/default-sport.png"
        },
        "name": "100 metros"
    }
]
```

Adicional tambien se hizo un refactoring del detalle de FK sobre los modelos de participaciones y comentarios.
Tambien se habilito la paginacion solo para los atletas.